### PR TITLE
[codex] Add frontend shell and dark neobrutalist base

### DIFF
--- a/networking-monorepo/docker/compose/dev.yml
+++ b/networking-monorepo/docker/compose/dev.yml
@@ -64,7 +64,7 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GATEWAY_BASE_URL: http://localhost:8086
-      FRONTEND_BASE_URL: http://localhost:4321
+      FRONTEND_BASE_URL: http://localhost:4321/app
       APP_SECURITY_ISSUER_URI: http://identity-provider:8081
     command: sh -c "cd services/identity-provider && ./gradlew --project-cache-dir /tmp/gradle-project-cache bootRunInContainer"
 

--- a/networking-monorepo/frontend/src/layouts/AppLayout.astro
+++ b/networking-monorepo/frontend/src/layouts/AppLayout.astro
@@ -1,5 +1,10 @@
 ---
-const { title = "App · Westats" } = Astro.props;
+import "../styles/base.css";
+
+const {
+  title = "App · Westats",
+  currentPath = "/app"
+} = Astro.props;
 ---
 <!doctype html>
 <html lang="en">
@@ -10,18 +15,16 @@ const { title = "App · Westats" } = Astro.props;
   </head>
   <body>
     <header>
-      <nav>
-        <a href="/app">Westats App</a>
-        <a href="/">Public Site</a>
-        <a href="/login">Logout</a>
+      <nav class="topbar">
+        <a href="/app" class="brand">Westats</a>
+        <div class="topbar-menu">
+          <a href="/app" class:list={{ active: currentPath === "/app" }}>Home</a>
+          <a href="/app/insights" class:list={{ active: currentPath === "/app/insights" }}>Insights</a>
+          <a href="/app/cards" class:list={{ active: currentPath === "/app/cards" }}>Cards</a>
+        </div>
+        <a href="/login" class="logout-link">Account</a>
       </nav>
     </header>
-
-    <aside>
-      <ul>
-        <li><a href="/app">Home</a></li>
-      </ul>
-    </aside>
 
     <main>
       <slot />

--- a/networking-monorepo/frontend/src/layouts/AuthLayout.astro
+++ b/networking-monorepo/frontend/src/layouts/AuthLayout.astro
@@ -1,4 +1,6 @@
 ---
+import "../styles/base.css";
+
 const { title = "Login · Westats" } = Astro.props;
 ---
 <!doctype html>

--- a/networking-monorepo/frontend/src/layouts/PublicLayout.astro
+++ b/networking-monorepo/frontend/src/layouts/PublicLayout.astro
@@ -1,4 +1,6 @@
 ---
+import "../styles/base.css";
+
 const { title = "Westats" } = Astro.props;
 ---
 <!doctype html>
@@ -9,13 +11,6 @@ const { title = "Westats" } = Astro.props;
     <title>{title}</title>
   </head>
   <body>
-    <header>
-      <nav>
-        <a href="/">Westats</a>
-        <a href="/login">Login</a>
-      </nav>
-    </header>
-
     <main>
       <slot />
     </main>

--- a/networking-monorepo/frontend/src/pages/app/index.astro
+++ b/networking-monorepo/frontend/src/pages/app/index.astro
@@ -25,9 +25,43 @@ try {
 } catch (error) {
   loadError = error instanceof Error ? error.message : "Unknown error";
 }
+
+const channelTitle = me?.email
+  ? `${me.email.split("@")[0]}'s Channel`
+  : "Channel Overview";
+
+const factItems = me
+  ? [
+      { label: "Email", value: me.email ?? "N/A" },
+      { label: "Session", value: me.sessionId ?? "N/A" },
+      { label: "Tenant", value: me.tenantId ?? "N/A" }
+    ]
+  : [];
 ---
-<AppLayout title="App Home · Westats">
-  <h1>App Home</h1>
+<AppLayout title={`${channelTitle} · Westats`} currentPath="/app">
+  <section class="channel-banner">
+    <div class="channel-badge" aria-hidden="true">
+      {channelTitle.slice(0, 1)}
+    </div>
+
+    <div class="channel-banner-copy">
+      <p class="channel-kicker">Channel</p>
+      <h1>{channelTitle}</h1>
+
+      {factItems.length ? (
+        <dl class="channel-facts">
+          {factItems.map((item) => (
+            <div>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p class="channel-empty">Sign in to load channel details.</p>
+      )}
+    </div>
+  </section>
 
   {me ? (
     <>

--- a/networking-monorepo/frontend/src/styles/base.css
+++ b/networking-monorepo/frontend/src/styles/base.css
@@ -1,0 +1,382 @@
+:root {
+  --bg: #0f0f12;
+  --bg-alt: #1a1a20;
+  --panel: #22222b;
+  --panel-2: #2b2b36;
+  --text: #f4efe6;
+  --muted: #b7af9f;
+  --line: #f4efe6;
+  --accent: #ffd84d;
+  --accent-2: #ff6b57;
+  --success: #63f29a;
+  --shadow: 6px 6px 0 #000;
+  --radius: 0;
+  --content-width: 72rem;
+  --font-sans: "Space Grotesk", "Arial Black", sans-serif;
+  --font-mono: "IBM Plex Mono", "Courier New", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  background:
+    linear-gradient(180deg, rgba(255, 107, 87, 0.08), transparent 24rem),
+    linear-gradient(135deg, #15151b, #09090b 65%);
+  color: var(--text);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  background:
+    linear-gradient(90deg, rgba(255, 216, 77, 0.06) 1px, transparent 1px),
+    linear-gradient(rgba(255, 216, 77, 0.06) 1px, transparent 1px);
+  background-size: 24px 24px;
+  background-color: transparent;
+}
+
+a,
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+header,
+section,
+article,
+nav,
+form,
+dl,
+ul,
+ol,
+blockquote,
+pre,
+table {
+  border: 3px solid var(--line);
+  box-shadow: var(--shadow);
+  background: var(--panel);
+}
+
+header,
+main {
+  width: min(calc(100% - 2rem), var(--content-width));
+  margin-inline: auto;
+}
+
+header {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  background: var(--accent-2);
+  color: #111;
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+.topbar-menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.topbar-menu a {
+  background: var(--text);
+}
+
+.topbar-menu a.active {
+  background: var(--accent);
+}
+
+nav a {
+  padding: 0.55rem 0.85rem;
+  border: 3px solid #111;
+  background: var(--accent);
+  color: #111;
+  font-weight: 700;
+  text-transform: uppercase;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.9);
+}
+
+nav a:nth-child(even) {
+  background: var(--text);
+}
+
+.brand {
+  font-size: 1.1rem;
+  color: #111;
+}
+
+.logout-link {
+  background: var(--accent-2);
+}
+
+main {
+  margin-top: 1rem;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 0.75rem;
+  font-weight: 900;
+  line-height: 0.95;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+h1 {
+  font-size: clamp(2.6rem, 7vw, 5.5rem);
+  text-wrap: balance;
+}
+
+h2 {
+  font-size: clamp(1.8rem, 4vw, 3rem);
+}
+
+p,
+li,
+dd,
+dt,
+label {
+  font-size: 1rem;
+}
+
+p,
+ul,
+ol,
+dl {
+  margin: 0 0 1rem;
+}
+
+ul,
+ol {
+  padding-left: 1.25rem;
+}
+
+dt {
+  font-weight: 800;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 0 0 0.9rem;
+  color: var(--muted);
+}
+
+.channel-banner {
+  display: grid;
+  grid-template-columns: clamp(5.5rem, 12vw, 7rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: var(--panel-2);
+}
+
+.channel-badge {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border: 3px solid var(--line);
+  background: var(--accent);
+  color: #111;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  box-shadow: var(--shadow);
+}
+
+.channel-banner-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.channel-kicker {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.channel-banner-copy h1 {
+  margin-bottom: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.channel-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.channel-facts div {
+  min-width: 0;
+  padding: 0.75rem;
+  border: 3px solid var(--line);
+  background: #111;
+  box-shadow: var(--shadow);
+}
+
+.channel-facts dt,
+.channel-facts dd {
+  margin: 0;
+}
+
+.channel-facts dd {
+  margin-top: 0.35rem;
+  color: var(--text);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.channel-empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+main a,
+nav a {
+  display: inline-block;
+}
+
+main a {
+  display: inline-block;
+  padding: 0.35rem 0.55rem;
+  border: 2px solid var(--line);
+  background: #111;
+}
+
+nav a:hover,
+main a:hover,
+button:hover,
+.button:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 #000;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border: 3px solid var(--line);
+  background: #111;
+  color: var(--text);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+button,
+.button {
+  display: inline-block;
+  padding: 0.8rem 1rem;
+  border: 3px solid #111;
+  background: var(--success);
+  color: #111;
+  font-weight: 800;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+
+code,
+pre {
+  font-family: var(--font-mono);
+}
+
+code {
+  padding: 0.15rem 0.35rem;
+  border: 2px solid var(--line);
+  background: #111;
+}
+
+pre {
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+@media (max-width: 720px) {
+  body {
+    background-size: 18px 18px;
+  }
+
+  header,
+  main {
+    width: min(calc(100% - 1rem), var(--content-width));
+  }
+
+  header,
+  .channel-banner {
+    padding: 1rem;
+  }
+
+  .topbar,
+  .topbar-menu {
+    gap: 0.5rem;
+  }
+
+  .brand,
+  .logout-link,
+  .topbar-menu a {
+    width: 100%;
+    text-align: center;
+  }
+
+  .channel-banner {
+    grid-template-columns: 1fr;
+  }
+
+  .channel-badge {
+    width: min(100%, 5rem);
+    justify-self: start;
+  }
+
+  .channel-facts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/networking-monorepo/services/identity-provider/src/main/resources/application.yml
+++ b/networking-monorepo/services/identity-provider/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
 app:
   gateway-url: ${GATEWAY_BASE_URL:http://localhost:8080}
-  frontend-url: ${FRONTEND_BASE_URL:http://localhost:4321}
+  frontend-url: ${FRONTEND_BASE_URL:http://localhost:4321/app}
 
 auth:
   session:


### PR DESCRIPTION
## What changed

- add shared dark neobrutalist base stylesheet for frontend layouts
- reshape app shell around a top bar with active-route highlighting
- add channel banner on app home with badge, title, and basic facts
- remove public landing navbar so the page can evolve into a hero screen
- update IDP frontend redirect target so login lands on `/app`

## Why

The frontend needed a lightweight but coherent base before deeper page work. This gives the app a usable shell and a stronger visual direction without overcommitting to final design.

It also makes the current login flow land in the application entry point instead of the public landing page.

## Impact

- public/auth/app layouts now share one base CSS file
- app home has a more intentional dashboard header structure
- landing page is now cleaner and ready for full SaaS hero treatment later
- post-login redirect points at `/app`

## Validation

- frontend CSS/layout changes reviewed locally
- `pnpm build` still cannot serve as a full check here because the Astro app has SSR pages but no adapter configured

<img width="1925" height="1363" alt="image" src="https://github.com/user-attachments/assets/bfc48f60-93ee-4436-a35e-932722ac1c06" />
