### PR TITLE
[codex] Fix dev Kafka bootstrap with OpenTofu

### DIFF
--- a/networking-monorepo/docker/compose/infra.kafka.yml
+++ b/networking-monorepo/docker/compose/infra.kafka.yml
@@ -8,25 +8,38 @@ services:
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
     volumes:
       - kafka-data:/var/lib/kafka/data
+    healthcheck:
+      test: ["CMD-SHELL", "cub kafka-ready -b localhost:9092 1 30"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
 
 
   kafka-topics:
     image: ghcr.io/opentofu/opentofu:latest
     working_dir: /infra/kafka
+    entrypoint: ["/bin/sh", "-c"]
     volumes:
       - ../../infra/kafka:/infra/kafka
     depends_on:
-      - kafka
-    command: >
-      sh -c "tofu init && tofu apply -auto-approve"
+      kafka:
+        condition: service_healthy
+    command:
+      - "tofu init && tofu apply -auto-approve"
 
 volumes:
   kafka-data:

--- a/networking-monorepo/infra/kafka/main.tf
+++ b/networking-monorepo/infra/kafka/main.tf
@@ -9,4 +9,6 @@ terraform {
 
 provider "kafka" {
   bootstrap_servers = ["kafka:9092"]
+  kafka_version     = "3.6.0"
+  tls_enabled       = false
 }

--- a/networking-monorepo/infra/kafka/topics.tf
+++ b/networking-monorepo/infra/kafka/topics.tf
@@ -1,0 +1,32 @@
+resource "kafka_topic" "ingestion_channel_commands" {
+  name               = "ingestion.channel.commands"
+  partitions         = 3
+  replication_factor = 1
+
+  config = {
+    "cleanup.policy" = "delete"
+    "retention.ms"   = "604800000" # 7 days
+  }
+}
+
+resource "kafka_topic" "ingestion_analytics_commands" {
+  name               = "ingestion.analytics.commands"
+  partitions         = 3
+  replication_factor = 1
+
+  config = {
+    "cleanup.policy" = "delete"
+    "retention.ms"   = "604800000"
+  }
+}
+
+resource "kafka_topic" "ingestion_events" {
+  name               = "ingestion.events"
+  partitions         = 3
+  replication_factor = 1
+
+  config = {
+    "cleanup.policy" = "delete"
+    "retention.ms"   = "604800000"
+  }
+}


### PR DESCRIPTION
## What changed

- configure the dev Kafka broker for stable single-node KRaft startup
- add a Kafka healthcheck and make the topic bootstrap wait for broker readiness
- fix the `kafka-topics` compose command so OpenTofu actually runs through a shell entrypoint
- make the OpenTofu Kafka provider explicit for the local plaintext broker
- add the topic definitions in `infra/kafka/topics.tf`

## Why

The dev stack was not bringing Kafka up cleanly, and the topic bootstrap job either failed before the broker was ready or did not execute the OpenTofu command correctly.

This change makes the local Kafka setup boot reliably and restores `topics.tf` as the source of truth for topic creation in dev.

## Impact

- `docker compose -f docker/compose/dev.yml --profile dev up -d --build` now has a working Kafka broker path
- Kafka topics are created from OpenTofu after broker readiness, instead of depending on manual recovery
- local topic bootstrap stays aligned with the infra definition rather than a one-off CLI workaround

## Validation

- recreated `kafka` and `kafka-topics` containers
- verified Kafka reaches healthy state
- verified `kafka-topics` completes with:
  - `Apply complete! Resources: 3 added, 0 changed, 0 destroyed.`
