### PR TITLE
[codex] Fix OAuth login endpoint redirects

### DIFF
--- a/networking-monorepo/frontend/src/lib/auth.js
+++ b/networking-monorepo/frontend/src/lib/auth.js
@@ -27,7 +27,7 @@ export function getTransientCookieOptions(url) {
 
 export function getGoogleAuthorizationUrl(env) {
   const backendUrl =
-    env.INTERNAL_BACKEND_URL ?? env.PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+    env.PUBLIC_BACKEND_URL ?? env.INTERNAL_BACKEND_URL ?? "http://localhost:8080";
 
   return `${backendUrl}/api/idp/oauth2/authorization/google`;
 }

--- a/networking-monorepo/frontend/src/pages/auth/google.ts
+++ b/networking-monorepo/frontend/src/pages/auth/google.ts
@@ -5,12 +5,23 @@ import {
   sanitizeDeviceField
 } from "../../lib/auth.js";
 
+export const prerender = false;
+
 const redirectStatus = 303;
 
+function canReadFormData(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+
+  return (
+    contentType.includes("application/x-www-form-urlencoded") ||
+    contentType.includes("multipart/form-data")
+  );
+}
+
 export const POST: APIRoute = async ({ request, cookies, redirect, url }) => {
-  const formData = await request.formData();
-  const deviceOs = sanitizeDeviceField(formData.get("deviceOs"), 120);
-  const deviceScreen = sanitizeDeviceField(formData.get("deviceScreen"), 64);
+  const formData = canReadFormData(request) ? await request.formData() : null;
+  const deviceOs = sanitizeDeviceField(formData?.get("deviceOs") ?? null, 120);
+  const deviceScreen = sanitizeDeviceField(formData?.get("deviceScreen") ?? null, 64);
   const cookieOptions = getTransientCookieOptions(url);
 
   if (deviceOs) {


### PR DESCRIPTION
## What changed
- made the frontend OAuth initiation URL prefer `PUBLIC_BACKEND_URL` over the internal Docker-only backend hostname
- marked `/auth/google` as non-prerendered so Astro can handle POST requests at runtime
- made the endpoint tolerate requests that do not carry a form-encoded body before reading device metadata

## Why
After merging the device/OAuth work, the browser was being redirected to the internal `gateway` hostname, which is only resolvable inside Docker. The Astro endpoint was also still behaving like a static endpoint in dev, and it could throw when `formData()` was called on requests without a form content type.

## Impact
- browser login should now redirect to the public backend URL (`localhost` in dev) instead of `gateway`
- `/auth/google` can accept runtime POST requests safely
- device metadata remains optional and no longer blocks the OAuth redirect path

## Validation
- reproduced and traced the failures through container logs
- confirmed frontend now emits `303 POST /auth/google` without the previous static-endpoint error
- identity-provider and gateway were restarted and reached healthy startup after the fix path was verified
